### PR TITLE
Fixing OSQUERY_DEPS in building documentation

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -273,12 +273,11 @@ OSQUERY_BUILD_DEPS=True # Install dependencies from source when using make deps
 OSQUERY_BUILD_BOTTLES=True # Create bottles from installed dependencies
 OSQUERY_BUILD_VERSION=9.9.9 # Set a wacky version string
 OSQUERY_PLATFORM=custom_linux;1.0 # Set a wacky platform/distro name
-OSQUERY_OSQUERY_DEPS=/usr/local/osquery # Set alternative dependency path
+OSQUERY_DEPS=/usr/local/osquery # Set alternative dependency path
 OSQUERY_NOSUDO=True # If sudo is not available to user building osquery
 SDK_VERSION=9.9.9 # Set a wacky SDK-version string.
 OSX_VERSION_MIN=10.11 # Override the native minimum macOS version ABI
 OSX_VERSION_NATIVE=True # Set the macOS version ABI to the build system ABI
-OSQUERY_DEPS=/path/to/dependencies # Use a custom dependency environment
 FAST=True # Build and link as quick as possible.
 SANITIZE_THREAD=True # Add -fsanitize=thread when using "make sanitize"
 SANITIZE_UNDEFINED=True # Add -fsanitize=undefined when using "make sanitize"


### PR DESCRIPTION
There's no mention for `OSQUERY_OSQUERY_DEPS` in the codebase, according to the default value I think [OSQUERY_DEPS](https://github.com/facebook/osquery/blob/967910c6bf008afff0e05b1347d8857a3daa80da/tools/provision.sh#L193) was the one intended. OSQUERY_DEPS was already mentioned, so I deleted it.